### PR TITLE
Support python2 platform

### DIFF
--- a/freezedata/__init__.py
+++ b/freezedata/__init__.py
@@ -1,8 +1,8 @@
 import os
 from .freezedata import freeze_data
 
-DIR = os.path.dirname(__file__)
-README = os.path.join(DIR, 'README.rst')
+
+__all__ = ['freeze_data']
 
 __doc__ = """
 Recursively convert lists to tuples, sets to frozensets, dicts to mappingproxy etc.
@@ -32,5 +32,3 @@ hashable either::
    >> TypeError: unhashable type: 'mappingproxy'
 """
 
-del os, DIR, README
-del freezedata

--- a/freezedata/freezedata.py
+++ b/freezedata/freezedata.py
@@ -1,8 +1,20 @@
 import types
 from collections import namedtuple
 
+if not hasattr(types, "MappingProxyType"):
+    # to support Python2 platform
+    try:
+        from frozen_dict import FrozenDict as MappingProxyType
+    except ImportError:
+        try:
+            from frozendict import frozendict as MappingProxyType
+        except ImportError:
+            # use default dict instead (making more sense then raising exception)
+            MappingProxyType = dict
 
-def freeze_data(obj, *, allow=frozenset()):
+    types.MappingProxyType = MappingProxyType
+
+def freeze_data(obj, allow=frozenset()):
     """Convert 'obj' recursively to a read-only object but selectively
     allow functions, modules and other hashables, which may not be read-only.
     This means that recursively:
@@ -52,7 +64,7 @@ def freeze_data(obj, *, allow=frozenset()):
         return freeze_data_inner(obj, allow=allow)
 
 
-def freeze_data_inner(obj, *, allow=frozenset()):
+def freeze_data_inner(obj, allow=frozenset()):
     # check type and recursively return a new read-only object
     if isinstance(obj, (str, int, float, bytes, type(None), bool)):
         return obj

--- a/freezedata/freezedata.py
+++ b/freezedata/freezedata.py
@@ -60,7 +60,6 @@ def freeze_data(obj, allow=frozenset()):
     if isinstance(obj, types.ModuleType):
         return freeze_class_or_istance_or_module(obj, allow=allow)
     else:
-        print(123)
         return freeze_data_inner(obj, allow=allow)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+frozendict


### PR DESCRIPTION
 Support python2 platform with hacking types.MappingProxyType as frozendict.frozendict (or frozen_dict.FrozenDict)